### PR TITLE
Fix YAML Date parsing

### DIFF
--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'yaml'
 require 'json'
+require 'date'
 
 # TODO: Support JSON
 class RSpec::OpenAPI::SchemaFile
@@ -24,7 +25,12 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    RSpec::OpenAPI::KeyTransformer.symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
+    RSpec::OpenAPI::KeyTransformer.symbolize(
+      YAML.safe_load(
+        File.read(@path),
+        permitted_classes: [Date],
+      ),
+    )
   end
 
   # @param [Hash] spec

--- a/spec/rspec/schema_file_spec.rb
+++ b/spec/rspec/schema_file_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+require 'date'
+
+RSpec.describe RSpec::OpenAPI::SchemaFile do
+  include SpecHelper
+
+  it 'reads YAML with Date objects' do
+    Tempfile.create(['openapi', '.yaml']) do |file|
+      file.write("date: 2024-05-10\n")
+      file.close
+      loaded_schema = nil
+      RSpec::OpenAPI::SchemaFile.new(file.path).edit do |spec|
+        loaded_schema = spec
+      end
+      expect(loaded_schema).to eq(date: Date.new(2024, 5, 10))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow `Date` objects when reading schema files
- add spec covering YAML with Date value

## Testing
- `bundle exec rubocop`
- `bundle exec rspec spec/rspec/schema_file_spec.rb` *(fails: cannot load mutex_m)*

------
https://chatgpt.com/codex/tasks/task_e_684ac66963dc8331a8256426f86904ad