### PR TITLE
Fix YAML load with Date and Time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :test do
   gem 'simplecov', git: 'https://github.com/exoego/simplecov.git', branch: 'branch-fix'
   gem 'simplecov-cobertura'
   gem 'super_diff'
+  gem 'mutex_m'
 end
 
 group :development do

--- a/lib/rspec/openapi/schema_file.rb
+++ b/lib/rspec/openapi/schema_file.rb
@@ -3,6 +3,8 @@
 require 'fileutils'
 require 'yaml'
 require 'json'
+require 'date'
+require 'time'
 
 # TODO: Support JSON
 class RSpec::OpenAPI::SchemaFile
@@ -24,7 +26,9 @@ class RSpec::OpenAPI::SchemaFile
   def read
     return {} unless File.exist?(@path)
 
-    RSpec::OpenAPI::KeyTransformer.symbolize(YAML.safe_load(File.read(@path))) # this can also parse JSON
+    RSpec::OpenAPI::KeyTransformer.symbolize(
+      YAML.safe_load(File.read(@path), permitted_classes: [Date, Time]),
+    )
   end
 
   # @param [Hash] spec

--- a/spec/rspec/schema_file_spec.rb
+++ b/spec/rspec/schema_file_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe RSpec::OpenAPI::SchemaFile do
+  include SpecHelper
+
+  it 'reads YAML with unquoted date' do
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'openapi.yml')
+      File.write(path, <<~YAML)
+        updated_at: 2025-06-10 01:47:28Z
+      YAML
+      schema_file = described_class.new(path)
+      result = schema_file.send(:read)
+      expect(result[:updated_at]).to eq(Time.utc(2025, 6, 10, 1, 47, 28))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow Date and Time when reading YAML schema files
- add regression test for SchemaFile
- include mutex_m in test dependencies

Fixes #249


------
https://chatgpt.com/codex/tasks/task_e_684ac6981eac833199f286a6fec49170